### PR TITLE
Admin add variants to cart

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - '*.gemspec'
     - 'bin/*'
     - 'Gemfile*'
-    - 'spec/dummy/**/*'
+    - 'spec/**/*'
     - 'vendor/bundle/**/*'
   TargetRubyVersion: 2.3
 

--- a/app/controllers/spree/admin/premade_carts_controller.rb
+++ b/app/controllers/spree/admin/premade_carts_controller.rb
@@ -7,6 +7,16 @@ module Spree
         respond_with(@collection)
       end
 
+      def new
+        if params[:variant_ids].present?
+          variant_ids = params[:variant_ids].map(&:to_i)
+          variant_ids.each do |variant_id|
+            @object.premade_cart_variants.build(variant_id: variant_id)
+          end
+        end
+        super
+      end
+
       def show
         redirect_to action: :edit
       end

--- a/app/models/spree/premade_cart.rb
+++ b/app/models/spree/premade_cart.rb
@@ -5,6 +5,8 @@ module Spree
     has_many :premade_cart_variants, class_name: 'Spree::PremadeCartVariant', dependent: :destroy
     has_many :variants, class_name: 'Spree::Variant', through: :premade_cart_variants
 
+    accepts_nested_attributes_for :premade_cart_variants, allow_destroy: true
+
     validates :name, presence: true
     validates :token, presence: true, uniqueness: true
 

--- a/app/overrides/add_create_premade_cart_from_variant_link.rb
+++ b/app/overrides/add_create_premade_cart_from_variant_link.rb
@@ -1,0 +1,10 @@
+# Add a link to create a premade cart with the master variant
+
+override_params = {
+  virtual_path: 'spree/admin/products/_form',
+  name: 'add_create_premade_cart_variant_links',
+  insert_after: "[data-hook='admin_product_form_sku']",
+  text: "<div data-hook='admin_product_create_cart'><%= link_to 'create cart', new_admin_premade_cart_path('variant_ids[]' => @product.master.id) %></div>",
+}
+
+Deface::Override.new(override_params)

--- a/app/views/spree/admin/premade_carts/_form.html.erb
+++ b/app/views/spree/admin/premade_carts/_form.html.erb
@@ -37,6 +37,22 @@
     </div>
   </div>
 
+  <div class="row" >
+      <div class="left col-9">
+          Variants:
+          <ul>
+              <%= f.fields_for :premade_cart_variants do |ff| %>
+                  <% variant = ff.object.variant %>
+                  <li>
+                      <%= ff.hidden_field :premade_cart_id %>
+                      <%= ff.hidden_field :variant_id %>
+                      <%= variant.sku %>
+                  </li>
+              <% end %>
+          </ul>
+      </div>
+  </div>
+
   <div class="clear"></div>
 
   <div data-hook="admin_premade_cart_form_additional_fields"></div>

--- a/spec/features/admin/premade_carts/manage_premade_carts_spec.rb
+++ b/spec/features/admin/premade_carts/manage_premade_carts_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe 'Premade Cart Management', type: :feature do
   stub_authorization!
 
   let!(:premade_cart) { create(:premade_cart, name: 'First Bundle') }
+  let!(:product_wo_variants) { create(:product) }
+  let(:master) { product_wo_variants.master }
+  # let!(:product_with_variants) { create(:product_with_variants) }
 
   scenario 'Admin has a link to manage premade carts', js: true do
     visit spree.admin_orders_path
@@ -17,6 +20,18 @@ RSpec.describe 'Premade Cart Management', type: :feature do
     fill_in 'Name', with: 'Awesome Bundle Offer'
     click_button 'Create'
     expect(page).to have_text('Awesome Bundle Offer')
+  end
+
+  scenario 'Admin creates a cart from a product master variant', js: true do
+    visit spree.admin_products_path
+    click_link product_wo_variants.name
+    click_link 'create cart'
+    expect(page).to have_text(master.sku)
+    fill_in 'Name', with: 'Buy this product offer'
+    click_button 'Create'
+    expect(page).to have_text('Buy this product offer')
+    click_link 'Buy this product offer'
+    expect(page).to have_text(master.sku)
   end
 
   scenario 'Admin updates a premade cart' do


### PR DESCRIPTION
As a store owner, I want to be able to contsruct URLs that will perform the following actions when clicked:

1. Add a variant to the clicking customer's shopping cart
2. Redirect the clicking customer to the checkout page

This will allow store owners to construct ad campaigns around buying specific items.