### PR TITLE
Gate menu item based on ability

### DIFF
--- a/lib/generators/solidus_premade_carts/install/premade_carts_initializer.rb
+++ b/lib/generators/solidus_premade_carts/install/premade_carts_initializer.rb
@@ -2,7 +2,8 @@ if Spree::Backend::Config.respond_to?(:menu_items)
   Spree::Backend::Config.configure do |config|
     config.menu_items << config.class::MenuItem.new(
       [:premade_carts],
-      label: 'Premade Carts'
+      label: 'Premade Carts',
+      condition: -> { can?(:manage, Spree::PremadeCart) }
     )
   end
 end


### PR DESCRIPTION
Gate the display of the menu link to manage premade carts based on the
current user's abilities. This is required for multitenancy.