### PR TITLE
Pin sqlite3 version

### DIFF
--- a/solidus_premade_carts.gemspec
+++ b/solidus_premade_carts.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,8 +6,20 @@ require 'chromedriver-helper'
 RSpec.configure do |config|
   config.include Rack::Test::Methods, type: :requests
 
+  Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
+
+  Chromedriver.set_version '2.45'
+
   Capybara.javascript_driver = :selenium
   Capybara.register_driver :selenium do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(
+        chromeOptions: { args: %w[ headless disable-gpu window-size=1280,1024 ] }
+      )
+    )
   end
+
+
 end


### PR DESCRIPTION
To maintain compatibility, sqlite3 needs to be pinned to 1.3.x. Also, we
add the config required to run selenium headless.

@jtapia this should resolve the spec fails in https://github.com/geminimvp/solidus_premade_carts/pull/10